### PR TITLE
[#1] 특정 도메인만 HTTP 통신 허용 설정

### DIFF
--- a/TMT/TMT.xcodeproj/project.pbxproj
+++ b/TMT/TMT.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		D867396E2CA933CD00FFE8ED /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		D86739702CA933CE00FFE8ED /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		D86739732CA933CE00FFE8ED /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		D8C7FB7C2CB3E342007B1B3E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -56,6 +57,7 @@
 				D8C7FB7A2CB3D88E007B1B3E /* BusStopSearch */,
 				D8C7FB7B2CB3D89B007B1B3E /* BusJourney */,
 				D86739702CA933CE00FFE8ED /* Assets.xcassets */,
+				D8C7FB7C2CB3E342007B1B3E /* Info.plist */,
 				D86739722CA933CE00FFE8ED /* Preview Content */,
 			);
 			path = TMT;
@@ -292,6 +294,8 @@
 				DEVELOPMENT_TEAM = 7P5S729LQZ;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = TMT/Info.plist;
+				INFOPLIST_KEY_LSApplicationCategoryType = "";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -323,6 +327,8 @@
 				DEVELOPMENT_TEAM = 7P5S729LQZ;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = TMT/Info.plist;
+				INFOPLIST_KEY_LSApplicationCategoryType = "";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;

--- a/TMT/TMT.xcodeproj/project.pbxproj
+++ b/TMT/TMT.xcodeproj/project.pbxproj
@@ -21,9 +21,9 @@
 		D867396E2CA933CD00FFE8ED /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		D86739702CA933CE00FFE8ED /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		D86739732CA933CE00FFE8ED /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
-		D8C7FB7C2CB3E342007B1B3E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		D8C160EB2CB4D85600818C1E /* BusStopSearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BusStopSearchView.swift; sourceTree = "<group>"; };
 		D8C160EE2CB4D86B00818C1E /* BusJourneyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BusJourneyView.swift; sourceTree = "<group>"; };
+		D8C7FB7C2CB3E342007B1B3E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */

--- a/TMT/TMT/Info.plist
+++ b/TMT/TMT/Info.plist
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSExceptionDomains</key>
+		<dict>
+			<key>ws.bus.go.kr/api/rest/arrive/getArrInfoByRoute</key>
+			<dict>
+				<key>NSExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
+				<key>NSIncluedsSubdomains</key>
+				<string></string>
+			</dict>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/TMT/TMT/Info.plist
+++ b/TMT/TMT/Info.plist
@@ -6,7 +6,7 @@
 	<dict>
 		<key>NSExceptionDomains</key>
 		<dict>
-			<key>ws.bus.go.kr/api/rest/arrive/getArrInfoByRoute</key>
+			<key>ws.bus.go.kr</key>
 			<dict>
 				<key>NSExceptionAllowsInsecureHTTPLoads</key>
 				<true/>


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요

- ATS 정책으로 HTTPS 통신을 권장하며 HTTP 통신을 하려면 추가 설정 작업이 필요해서 진햄함.
- 공공데이터 openAPI와 HTTP로 통신하기 위해, 특정 도메인만 HTTP 통신 허용함.


## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- 도메인 입력란에 baseURL인 `ws.bus.go.kr/api/rest/arrive/getArrInfoByRoute`을 넣어 놓긴 했는데, 동작 테스트 필요해요 ⚠️
